### PR TITLE
Make TEQUILA an extension

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -14,7 +14,12 @@ MillerExtendedHarmonic = "c82744c2-dc08-461a-8c37-87ab04d0f9b8"
 PlotUtils = "995b91a9-d308-5afd-9ec6-746e21dbc043"
 RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
+
+[weakdeps]
 TEQUILA = "a60c9cbd-e72f-4185-96b6-b8fc312c4d37"
+
+[extensions]
+TEQUILA_Ext = "TEQUILA"
 
 [compat]
 FastGaussQuadrature = "1"

--- a/ext/TEQUILA_Ext.jl
+++ b/ext/TEQUILA_Ext.jl
@@ -1,0 +1,52 @@
+module TEQUILA_Ext
+
+import VacuumFields, TEQUILA, MillerExtendedHarmonic, MXHEquilibrium
+
+"""
+    encircling_coils(shot::TEQUILA.Shot, n_coils::Int)
+
+Return a Vector of `n_coils` `PointCoil`s distributed outside of `shot`'s boundary
+"""
+function VacuumFields.encircling_coils(shot::TEQUILA.Shot, n_coils::Int)
+    bnd_r, bnd_z = MillerExtendedHarmonic.MXH(shot.surfaces[:, end])()
+    return VacuumFields.encircling_coils(bnd_r, bnd_z, n_coils)
+end
+
+"""
+    boundary_control_points(EQfixed::MXHEquilibrium.AbstractEquilibrium, fraction_inside::Float64=0.999, ψbound::Real=0.0; Npts::Integer=99)
+
+Return a Vector of FluxControlPoint, each with target `ψbound`, at `Npts` equally distributed `fraction_inside` percent inside the the boundary of `shot`
+"""
+function VacuumFields.boundary_control_points(shot::TEQUILA.Shot, fraction_inside::Float64=0.999, ψbound::Real=0.0; Npts::Integer=99)
+    bnd = MillerExtendedHarmonic.MXH(shot, fraction_inside)
+    θs = LinRange(0, 2π, Npts + 1)
+    ψtarget = ψbound + TEQUILA.psi_ρθ(shot, fraction_inside, 0.0)
+    return [VacuumFields.FluxControlPoint(bnd(θ)..., ψtarget, 1.0 / Npts) for θ in θs[1:end-1]]
+end
+
+"""
+    boundary_iso_control_points(EQfixed::MXHEquilibrium.AbstractEquilibrium, fraction_inside::Float64=0.999; Npts::Integer=99)
+
+Return a Vector of IsoControlPoints, at `Npts` equally distributed `fraction_inside` percent inside the the boundary of `shot`
+"""
+function VacuumFields.boundary_iso_control_points(shot::TEQUILA.Shot, fraction_inside::Float64=0.999; Npts::Integer=99)
+    bnd = MillerExtendedHarmonic.MXH(shot, fraction_inside)
+    θs = LinRange(0, 2π, Npts + 1)
+    r = [bnd(θ)[1] for θ in θs[1:end-1]]
+    z = [bnd(θ)[2] for θ in θs[1:end-1]]
+    return VacuumFields.IsoControlPoints(r, z)
+end
+
+VacuumFields.plasma_boundary_psi_w_fallback(shot::TEQUILA.Shot, args...) = MXHEquilibrium.Boundary(MXHEquilibrium.MXH(shot, 1.0)()...), 0.0
+
+function VacuumFields.Image(shot::TEQUILA.Shot)
+    bnd = @views MillerExtendedHarmonic.MXH(shot.surfaces[:, end])
+    return VacuumFields.Image(shot, bnd)
+end
+
+function VacuumFields.Image(shot::TEQUILA.Shot, bnd::MillerExtendedHarmonic.MXH; Nb::Integer=100 * (length(bnd.c) + 1))
+    image = VacuumFields.Image(shot, bnd(Nb; adaptive=false)...)
+    return image
+end
+
+end

--- a/src/VacuumFields.jl
+++ b/src/VacuumFields.jl
@@ -6,7 +6,6 @@ using Base.Threads
 using LinearAlgebra
 using RecipesBase
 import PlotUtils: cgrad
-import TEQUILA
 import FastGaussQuadrature: gausslegendre
 import StaticArrays: SMatrix, SVector
 import IMAS

--- a/src/coils.jl
+++ b/src/coils.jl
@@ -423,16 +423,6 @@ function encircling_coils(EQfixed::MXHEquilibrium.AbstractEquilibrium, n_coils::
 end
 
 """
-    encircling_coils(shot::TEQUILA.Shot, n_coils::Int)
-
-Return a Vector of `n_coils` `PointCoil`s distributed outside of `shot`'s boundary
-"""
-function encircling_coils(shot::TEQUILA.Shot, n_coils::Int)
-    bnd_r, bnd_z = MillerExtendedHarmonic.MXH(shot.surfaces[:, end])()
-    return encircling_coils(bnd_r, bnd_z, n_coils)
-end
-
-"""
     encircling_coils(bnd_r::AbstractVector{T}, bnd_z::AbstractVector{T}, n_coils::Int) where {T<:Real}
 
 Return a Vector of `n_coils` `PointCoil`s distributed outside of closed boundary defined by `bnd_r` and `bnd_z`

--- a/src/control.jl
+++ b/src/control.jl
@@ -163,18 +163,6 @@ function boundary_control_points(EQfixed::MXHEquilibrium.AbstractEquilibrium, fr
 end
 
 """
-    boundary_control_points(EQfixed::MXHEquilibrium.AbstractEquilibrium, fraction_inside::Float64=0.999, ψbound::Real=0.0; Npts::Integer=99)
-
-Return a Vector of FluxControlPoint, each with target `ψbound`, at `Npts` equally distributed `fraction_inside` percent inside the the boundary of `shot`
-"""
-function boundary_control_points(shot::TEQUILA.Shot, fraction_inside::Float64=0.999, ψbound::Real=0.0; Npts::Integer=99)
-    bnd = MillerExtendedHarmonic.MXH(shot, fraction_inside)
-    θs = LinRange(0, 2π, Npts + 1)
-    ψtarget = ψbound + TEQUILA.psi_ρθ(shot, fraction_inside, 0.0)
-    return [FluxControlPoint(bnd(θ)..., ψtarget, 1.0 / Npts) for θ in θs[1:end-1]]
-end
-
-"""
     boundary_iso_control_points(EQfixed::MXHEquilibrium.AbstractEquilibrium, fraction_inside::Float64=0.999; Npts::Integer=99)
 
 Return a Vector of IsoControlPoints, at `Npts` equally distributed `fraction_inside` percent inside the the boundary of `EQfixed`
@@ -183,19 +171,6 @@ function boundary_iso_control_points(EQfixed::MXHEquilibrium.AbstractEquilibrium
     ψ0, ψb = MXHEquilibrium.psi_limits(EQfixed)
     Sp = MXHEquilibrium.flux_surface(EQfixed, fraction_inside * (ψb - ψ0) + ψ0; n_interp=Npts)
     return VacuumFields.IsoControlPoints(Sp.r, Sp.z)
-end
-
-"""
-    boundary_iso_control_points(EQfixed::MXHEquilibrium.AbstractEquilibrium, fraction_inside::Float64=0.999; Npts::Integer=99)
-
-Return a Vector of IsoControlPoints, at `Npts` equally distributed `fraction_inside` percent inside the the boundary of `shot`
-"""
-function boundary_iso_control_points(shot::TEQUILA.Shot, fraction_inside::Float64=0.999; Npts::Integer=99)
-    bnd = MillerExtendedHarmonic.MXH(shot, fraction_inside)
-    θs = LinRange(0, 2π, Npts + 1)
-    r = [bnd(θ)[1] for θ in θs[1:end-1]]
-    z = [bnd(θ)[2] for θ in θs[1:end-1]]
-    return VacuumFields.IsoControlPoints(r, z)
 end
 
 """

--- a/src/fixed2free.jl
+++ b/src/fixed2free.jl
@@ -67,8 +67,6 @@ function plasma_boundary_psi_w_fallback(EQ::MXHEquilibrium.AbstractEquilibrium)
     return Sb, ψb
 end
 
-plasma_boundary_psi_w_fallback(shot::TEQUILA.Shot, args...) = MXHEquilibrium.Boundary(MXHEquilibrium.MXH(shot, 1.0)()...), 0.0
-
 """
     fixed2free(
         EQfixed::MXHEquilibrium.AbstractEquilibrium,

--- a/src/image.jl
+++ b/src/image.jl
@@ -21,15 +21,6 @@ function cumlength(R::T, Z::T) where {T<:AbstractVector{Float64}}
     return L
 end
 
-function Image(shot::TEQUILA.Shot)
-    bnd = @views MillerExtendedHarmonic.MXH(shot.surfaces[:, end])
-    return Image(shot, bnd)
-end
-function Image(shot::TEQUILA.Shot, bnd::MillerExtendedHarmonic.MXH; Nb::Integer=100 * (length(bnd.c) + 1))
-    image = Image(shot, bnd(Nb; adaptive=false)...)
-    return image
-end
-
 function Image(EQ::MXHEquilibrium.AbstractEquilibrium)
     Sb = MXHEquilibrium.plasma_boundary(EQ; precision=0.0)
     if Sb === nothing


### PR DESCRIPTION
This makes TEQUILA an extension (optional dependency), so VacuumFields doesn't carry TEQUILA inside of it. This makes the package lighter weight. For example, FRESCO was depending on TEQUILA, even though it never used it.