### PR TITLE
Add magnetic field control point and offset for iso control points

### DIFF
--- a/src/VacuumFields.jl
+++ b/src/VacuumFields.jl
@@ -41,8 +41,8 @@ include("elliptic.jl")
 include("green.jl")
 
 include("control.jl")
-export AbstractControlPoint, FluxControlPoint, SaddleControlPoint, IsoControlPoint
-export FluxControlPoints, SaddleControlPoints, IsoControlPoints
+export AbstractControlPoint, FluxControlPoint, SaddleControlPoint, IsoControlPoint, FieldControlPoint
+export FluxControlPoints, SaddleControlPoints, IsoControlPoints, IsoRefControlPoints, FieldControlPoints
 export find_coil_currents!, boundary_control_points
 
 include("fixed2free.jl")

--- a/src/VacuumFields.jl
+++ b/src/VacuumFields.jl
@@ -42,7 +42,7 @@ include("green.jl")
 
 include("control.jl")
 export AbstractControlPoint, FluxControlPoint, SaddleControlPoint, IsoControlPoint, FieldControlPoint
-export FluxControlPoints, SaddleControlPoints, IsoControlPoints, IsoRefControlPoints, FieldControlPoints
+export FluxControlPoints, SaddleControlPoints, IsoControlPoints, FieldControlPoints
 export find_coil_currents!, boundary_control_points
 
 include("fixed2free.jl")

--- a/src/control.jl
+++ b/src/control.jl
@@ -323,7 +323,7 @@ function find_coil_currents!(
         b .+= b_offset
     end
     weight_b!(b; flux_cps, saddle_cps, iso_cps, field_cps)
-    return _find_coil_currents!(coils, A, b; λ_regularize)
+    return find_coil_currents!(coils, A, b; λ_regularize)
 end
 
 """
@@ -417,7 +417,7 @@ function find_coil_currents!(
         b .+= b_offset
     end
     weight_b!(b; flux_cps, saddle_cps, iso_cps, field_cps)
-    _find_coil_currents!(coils, A, b; λ_regularize)
+    find_coil_currents!(coils, A, b; λ_regularize)
 end
 
 """
@@ -549,7 +549,7 @@ function find_coil_currents!(
         b .+= b_offset
     end
     weight_b!(b; flux_cps, saddle_cps, iso_cps, field_cps)
-    return _find_coil_currents!(coils, A, b; λ_regularize)
+    return find_coil_currents!(coils, A, b; λ_regularize)
 end
 
 """

--- a/src/control.jl
+++ b/src/control.jl
@@ -708,7 +708,7 @@ function init_b(
         k = Nflux + 2Nsaddle + Niso + i
 
         # subtract plasma contribution
-        b[k] -= (dψpl_dZ(r, z) * cos(cp.θ) - dψpl_dR(r, z) * sin(cp.θ)) / Bp_fac / r
+        b[k] -= cocos.sigma_RpZ * (dψpl_dZ(r, z) * cos(cp.θ) - dψpl_dR(r, z) * sin(cp.θ)) / Bp_fac / r
     end
 
     return b
@@ -809,7 +809,7 @@ function offset_b!(b::AbstractVector{T};
 
             # remove fixed coil contribution
             if !isempty(fixed_coils)
-                b[k] -= sum((dψ_dZ(fixed_coil, r, z; Bp_fac) * cos(cp.θ) - dψ_dR(fixed_coil, r, z; Bp_fac) * sin(cp.θ)) / Bp_fac / r for fixed_coil in fixed_coils)
+                b[k] -= sum(cocos.sigma_RpZ * (dψ_dZ(fixed_coil, r, z; Bp_fac) * cos(cp.θ) - dψ_dR(fixed_coil, r, z; Bp_fac) * sin(cp.θ)) / Bp_fac / r for fixed_coil in fixed_coils)
             end
         end
     end
@@ -951,7 +951,7 @@ function define_A(coils::AbstractVector{<:AbstractCoil};
             k = Nflux + 2Nsaddle + Niso + i
 
             # Build matrix relating coil Green's functions to boundary points
-            A[k, :] .= (dψ_dZ.(coils, r, z; Bp_fac) .* cos.(cp.θ) .- dψ_dR.(coils, r, z; Bp_fac) .* sin.(cp.θ)) ./ Bp_fac ./ r
+            A[k, :] .= cocos.sigma_RpZ .* (dψ_dZ.(coils, r, z; Bp_fac) .* cos.(cp.θ) .- dψ_dR.(coils, r, z; Bp_fac) .* sin.(cp.θ)) ./ Bp_fac ./ r
 
             # weighting
             w = sqrt(cp.weight)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -237,7 +237,7 @@ end
     currents_per_turn, _ = find_coil_currents!(coils, nothing; flux_cps, saddle_cps, iso_cps, field_cps)
     for flux_cp in flux_cps
         psi = sum(VacuumFields.ψ(coil, flux_cp.R, flux_cp.Z) for coil in coils)
-        @test isapprox(psi, flux_cp.target; rtol=tol)
+        @test isapprox(psi, flux_cp.target; atol=tol)
     end
     for saddle_cp in saddle_cps
         dpsidr = sum(VacuumFields.dψ_dR(coil, saddle_cp.R, saddle_cp.Z) for coil in coils)
@@ -252,7 +252,7 @@ end
     end
     for field_cp in field_cps
         b = sum((VacuumFields.dψ_dZ(coil, field_cp.R, field_cp.Z) * cos(field_cp.θ) - VacuumFields.dψ_dR(coil, field_cp.R, field_cp.Z) * sin(field_cp.θ)) / 2π / field_cp.R for coil in coils)
-        @test isapprox(b, field_cp.target; rtol=tol)
+        @test isapprox(b, field_cp.target; atol=tol)
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -224,7 +224,7 @@ end
 end
 
 @testset "all cp types" begin
-    tol = 100 * sqrt(eps())
+    tol = sqrt(eps())
     θ = range(0, 2π, 19)[1:end-1]
     Rs = 1.5 .+ 0.25 * cos.(θ)
     Zs = 0.5 * sin.(θ)
@@ -237,7 +237,7 @@ end
     currents_per_turn, _ = find_coil_currents!(coils, nothing; flux_cps, saddle_cps, iso_cps, field_cps)
     for flux_cp in flux_cps
         psi = sum(VacuumFields.ψ(coil, flux_cp.R, flux_cp.Z) for coil in coils)
-        @test isapprox(psi, flux_cp.target; atol=tol)
+        @test isapprox(psi, flux_cp.target; rtol=tol)
     end
     for saddle_cp in saddle_cps
         dpsidr = sum(VacuumFields.dψ_dR(coil, saddle_cp.R, saddle_cp.Z) for coil in coils)
@@ -252,7 +252,7 @@ end
     end
     for field_cp in field_cps
         b = sum((VacuumFields.dψ_dZ(coil, field_cp.R, field_cp.Z) * cos(field_cp.θ) - VacuumFields.dψ_dR(coil, field_cp.R, field_cp.Z) * sin(field_cp.θ)) / 2π / field_cp.R for coil in coils)
-        @test isapprox(b, field_cp.target; atol=tol)
+        @test isapprox(b, field_cp.target; rtol=tol)
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -223,6 +223,39 @@ end
     end
 end
 
+@testset "all cp types" begin
+    tol = 100 * sqrt(eps())
+    θ = range(0, 2π, 19)[1:end-1]
+    Rs = 1.5 .+ 0.25 * cos.(θ)
+    Zs = 0.5 * sin.(θ)
+    
+    # 18 control points total
+    flux_cps = [FluxControlPoint(Rs[3k+1], Zs[3k+1], 1.0 * k) for k in 0:3] # 4 flux control points
+    saddle_cps = [SaddleControlPoint(Rs[3k+2], Zs[3k+2]) for k in 0:2:4] # 3 saddle control points (2 constaints each)
+    iso_cps = [IsoControlPoint(Rs[3k+3], Zs[3k+3], Rs[1], Rs[2], k - 1.0) for k in 0:3] # 4 iso control points with offsets
+    field_cps = [FieldControlPoint(Rs[3k+1], Zs[3k+1], 1.0 * k, 1.0 * k * k) for k in 0:3] # 4 field control points
+    currents_per_turn, _ = find_coil_currents!(coils, nothing; flux_cps, saddle_cps, iso_cps, field_cps)
+    for flux_cp in flux_cps
+        psi = sum(VacuumFields.ψ(coil, flux_cp.R, flux_cp.Z) for coil in coils)
+        @test isapprox(psi, flux_cp.target; atol=tol)
+    end
+    for saddle_cp in saddle_cps
+        dpsidr = sum(VacuumFields.dψ_dR(coil, saddle_cp.R, saddle_cp.Z) for coil in coils)
+        @test isapprox(dpsidr, 0.0; atol=tol)
+        dpsidz = sum(VacuumFields.dψ_dZ(coil, saddle_cp.R, saddle_cp.Z) for coil in coils)
+        @test isapprox(dpsidz, 0.0; atol=tol)
+    end
+    for iso_cp in iso_cps
+        psi1 = sum(VacuumFields.ψ(coil, iso_cp.R1, iso_cp.Z1) for coil in coils)
+        psi2 = sum(VacuumFields.ψ(coil, iso_cp.R2, iso_cp.Z2) for coil in coils)
+        @test isapprox(psi1 - psi2, iso_cp.offset; atol=tol)
+    end
+    for field_cp in field_cps
+        b = sum((VacuumFields.dψ_dZ(coil, field_cp.R, field_cp.Z) * cos(field_cp.θ) - VacuumFields.dψ_dR(coil, field_cp.R, field_cp.Z) * sin(field_cp.θ)) / 2π / field_cp.R for coil in coils)
+        @test isapprox(b, field_cp.target; atol=tol)
+    end
+end
+
 # @testset "current_breakdown" begin
 
 #     # OH coils

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -224,7 +224,7 @@ end
 end
 
 @testset "all cp types" begin
-    tol = sqrt(eps())
+    tol = 100 * sqrt(eps())
     θ = range(0, 2π, 19)[1:end-1]
     Rs = 1.5 .+ 0.25 * cos.(θ)
     Zs = 0.5 * sin.(θ)


### PR DESCRIPTION
This is intended to be used for setting probe and flux loop control targets in FRESCO.

It also includes a new test for all of the different control point types that suggests they are setup properly.